### PR TITLE
[BUG] Server: stop read client buffer after disconnectClient #4

### DIFF
--- a/Server.hpp
+++ b/Server.hpp
@@ -102,17 +102,17 @@ class Server {
         User* findClientByNickname(const string& nickname);
         Channel* findChannelByName(const string& name);
 
-        void runCommand(User *user, Message& msg);
-        void cmdPrivmsg(User* user, Message& msg);
-        void cmdJoin(User* user, Message& msg);
-        void cmdPart(User* user, Message& msg);
-        void cmdPass(User *user, Message& msg);
-        void cmdNick(User *user, Message& msg);
-        void cmdUser(User *user, Message& msg);
-        void cmdPing(User *user, Message& msg);
-        void cmdQuit(User *user, Message& msg);
-        void cmdKick(User *user, Message& msg);
-        void cmdNotice(User *user, Message& msg);
+        bool runCommand(User *user, Message& msg);
+        bool cmdPrivmsg(User* user, Message& msg);
+        bool cmdJoin(User* user, Message& msg);
+        bool cmdPart(User* user, Message& msg);
+        bool cmdPass(User *user, Message& msg);
+        bool cmdNick(User *user, Message& msg);
+        bool cmdUser(User *user, Message& msg);
+        bool cmdPing(User *user, Message& msg);
+        bool cmdQuit(User *user, Message& msg);
+        bool cmdKick(User *user, Message& msg);
+        bool cmdNotice(User *user, Message& msg);
 
         friend class Message;
     public:


### PR DESCRIPTION
## Issue
- #4

## Explanation
- 클라이언트의 read 버퍼에서 crlf를 찾지 못하는 것을 조건문으로 check
- QUIT 커맨드 이후 client가 disconnect 된 경우에도 다시 해당 client의 버퍼를 check하는 문제가 발생
- disconnectClient 함수에서 이미 user에 대한 모든 메모리를 해제한 상태에서 접근을 하여 segmentation falut 발생

## Changed
- command 처리하는 함수의 return type을 boolean으로 변경
  - true: 버퍼를 계속해서 체크
  - false: client disconnected