### PR TITLE
[FIX] Server: check the return value of runCommand function #4, #9

### DIFF
--- a/Server.cpp
+++ b/Server.cpp
@@ -142,7 +142,7 @@ void Server::handleEvent(const struct kevent& event) {
 	{
 		if (event.ident == (const uintptr_t)_fd)
 			acceptNewClient();
-		else
+		else if (_allUser.find(event.ident) != _allUser.end())
 			readDataFromClient(event);
 	}
 	else if (event.filter == EVFILT_WRITE)
@@ -159,8 +159,7 @@ void Server::handleMessageFromBuffer(User* user) {
 		}
 		Message msg(user->getCmdBuffer().substr(0, crlfPos));
 		user->setCmdBuffer(user->getCmdBuffer().substr(crlfPos + 1, string::npos));
-		runCommand(user, msg);
-		
+		if (!runCommand(user, msg)) break;
 	}
 }
 


### PR DESCRIPTION
## Issue
- #4
- #9

## Explanation
- runCommand의 반환값을 통해 Buffer handling 여부를 판단하는 조건문 누락
- 조건문 처리 없이 iteration에서 이미 해제된 메모리에 접근하여 segmentation fault 발생

## Changed
- handleMessageFromBuffer 함수의 iteration에서 runCommand의 return 값에 따른 로직 분리
- true: user buffer checking 진행
- false: iteration 및 함수 종료

Co-authored-by: jaesjeon <jaesjeon@student.42seoul.kr>