### PR TITLE
[FIX] User: getNickname - empty nickname #8

### DIFF
--- a/User.cpp
+++ b/User.cpp
@@ -13,6 +13,8 @@ string User::getPassword(void) const {
 }
 
 string User::getNickname(void) const {
+    if (_nickname.empty()) return "*";
+    
     return _nickname;
 }
 


### PR DESCRIPTION
## Issue
- #8

## Explanation
- 최초 Connection 시 중복 nickname인 경우에 reply protocol이 준수되지 않았음
- 기존 코드에서는 empty nickname("")을 포함시켜 reply를 보내어 client가 이를 인식하지 못하고 무한히 packet을 주고 받는 현상 발생

## Changed
- empty nickname인 경우에는 "" 대신 "*"을 reply에 포함