### PR TITLE
[FIX] Server: cmdNick - reply message contains origin nickname

### DIFF
--- a/Server.cpp
+++ b/Server.cpp
@@ -363,15 +363,16 @@ bool Server::cmdNick(User *user, Message& msg) {
 		return true;
 	}
 	const string requestNickname = msg.getParams()[0];
+	const string originNickname = user->getNickname();
 
 	if (requestNickname.length() == 0) {
-		replyMsg << ":" << SERVER_HOSTNAME << ERR_NONICKNAMEGIVEN << user->getNickname() << ERR_NONICKNAMEGIVEN_MSG;
+		replyMsg << ":" << SERVER_HOSTNAME << ERR_NONICKNAMEGIVEN << originNickname << ERR_NONICKNAMEGIVEN_MSG;
 		user->addToReplyBuffer(replyMsg.createReplyForm());
 		return true;
 	}
 
 	if (findClientByNickname(requestNickname) != NULL) {
-		replyMsg << ":" << SERVER_HOSTNAME << ERR_NICKNAMEINUSE << user->getNickname() << requestNickname << ERR_NICKNAMEINUSE_MSG;
+		replyMsg << ":" << SERVER_HOSTNAME << ERR_NICKNAMEINUSE << originNickname << requestNickname << ERR_NICKNAMEINUSE_MSG;
 		user->addToReplyBuffer(replyMsg.createReplyForm());
 		return true;
 	}
@@ -391,7 +392,7 @@ bool Server::cmdNick(User *user, Message& msg) {
 			return false;
 		}
 	}
-	replyMsg << ":" << user->getNickname() << msg.getCommand() << requestNickname;
+	replyMsg << ":" << originNickname << msg.getCommand() << requestNickname;
 	user->addToReplyBuffer(replyMsg.createReplyForm());
 	return true;
 }


### PR DESCRIPTION
## Issue 
- #12

## Explanation
- nickname 변경 시, client가 변경 성공 메세지를 받지 못함
- reply message에 origin nickname을 넣어주어야 하는 위치에 변경된 nickname이 들어가는 부분이 있었음

## Changed
- setNickname을 하기 전에 origin nickname을 temporary하게 저장
- 추후 origin nickname을 reply에 추가

Co-authored-by: jaesjeon <jaesjeon@student.42seoul.kr>