### PR TITLE
[FIX] Command: PRIVMSG always put : front of text

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -39,16 +39,16 @@ bool Command::cmdPrivmsg(Server& server, User *user, const Message& msg) {
 				user->addToReplyBuffer(Message() << ":" << SERVER_HOSTNAME << ERR_NOSUCHNICK << user->getNickname() << targetName << ERR_NOSUCHNICK_MSG);
 				continue;
 			}
-            targetChannel->broadcast(Message() << ":" << user->getNickname() << msg.getCommand() << targetChannel->getName() << msg.getParams()[1], user->getFd());
+            targetChannel->broadcast(Message() << ":" << user->getNickname() << msg.getCommand() << targetChannel->getName() << ":" << msg.getParams()[1], user->getFd());
         } else {
             User *targetUser;
 
             targetUser = server.findClientByNickname(targetName);
             if (targetUser == NULL) {
-				user->addToReplyBuffer(Message() << string(":").append(SERVER_HOSTNAME) << ERR_NOSUCHNICK << user->getNickname() << targetName << ERR_NOSUCHNICK_MSG);
+				user->addToReplyBuffer(Message() << ":" << SERVER_HOSTNAME << ERR_NOSUCHNICK << user->getNickname() << targetName << ERR_NOSUCHNICK_MSG);
 				continue;
 			}
-            targetUser->addToReplyBuffer(Message() << ":" << user->getNickname() << msg.getCommand() << targetUser->getNickname() << msg.getParams()[1]);
+            targetUser->addToReplyBuffer(Message() << ":" << user->getNickname() << msg.getCommand() << targetUser->getNickname() << ":" << msg.getParams()[1]);
         }
     }
 	return true;


### PR DESCRIPTION
## Issue
- #17 

## Changed
- PRIVMSG의 메시지 내용 앞에 항상 ':'가 붙도록 변경되었습니다.
- 여러 params가 들어오는 경우와 dcc file transfer가 가능해졌습니다.

## ETC
- 기존에 ':'.append 로 되어있던 부분들도 수정되었습니다.

Co-authored-by: kyj93790 <kyj93790@naver.com>