### PR TITLE
[FIX] Modify conditional statement for checking empty nickname

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -212,7 +212,7 @@ bool Command::cmdUser(Server& server, User *user, const Message& msg) {
 	}
 	
 	user->setUsername(requestUserNickname);
-	if (!user->getNickname().empty()) {
+	if (user->getNickname() != "*") {
 		if (server.checkPassword(user->getPassword())) {
 			user->setAuth();
 			user->addToReplyBuffer(Message() << ":" << SERVER_HOSTNAME << RPL_WELCOME << user->getNickname() << ":Welcome to the" << SERVER_HOSTNAME <<  "Network" << requestUserNickname);


### PR DESCRIPTION
## Issue
- #22 

## Explanation
- getNickname() 함수에서 empty nickname인 경우 "*" 을 반환 (for nick change reply form)
- User에서 nickname empty check에서 getNickname 함수의 로직 고려없이 getNickname().empty()로 판단
- 항상 non empty로 판단하여 welcome message 전송되는 현상 발생

## Changed
- User에서 nickname empty check 로직을 empty() 함수 사용대신 **!= "*"** 로 수정