### PR TITLE
[BUG] Server: select user or channel with find method

### DIFF
--- a/Server.cpp
+++ b/Server.cpp
@@ -53,8 +53,11 @@ void Server::acceptNewClient(void) {
 
 void Server::readDataFromClient(const struct kevent& event) {
 	char buf[513];
-	User* targetUser = _allUser[event.ident];
+	map<int, User *>::iterator it = _allUser.find(event.ident);
+	User* targetUser = it->second;
 	int readBytes;
+
+	if (it == _allUser.end()) return ;
 
 	readBytes = read(event.ident, buf, 512);
 	if (readBytes <= 0) {
@@ -69,9 +72,11 @@ void Server::readDataFromClient(const struct kevent& event) {
 }
 
 void Server::sendDataToClient(const struct kevent& event) {
-	User *targetUser = _allUser[event.ident];
+	map<int, User *>::iterator it = _allUser.find(event.ident);
+	User* targetUser = it->second;
 	int readBytes;
 
+	if (it == _allUser.end()) return ;
 	if (targetUser->getReplyBuffer().empty()) return;
 
 	readBytes = write(event.ident, targetUser->getReplyBuffer().c_str(), targetUser->getReplyBuffer().length());
@@ -166,18 +171,23 @@ Channel* Server::addChannel(const string& name) {
 }
 
 void Server::deleteChannel(const string& name) {
-	Channel *ch = _allChannel[name];
+	map<string, Channel *>::iterator it = _allChannel.find(name);
+	Channel *ch = it->second;
 
+	if (it == _allChannel.end()) return ;
+	
 	_allChannel.erase(name);
 	delete ch;
 	cout << "channel deleted: " << name << '\n';
 }
 
 void Server::disconnectClient(int clientFd) {
-	User *user = _allUser[clientFd];
+	map<int, User *>::iterator it = _allUser.find(clientFd);
+	User* targetUser = it->second;
 
+	if (it == _allUser.end()) return ;
     _allUser.erase(clientFd);
-	delete user;
+	delete targetUser;
 	cout << "client disconnected: " << clientFd << '\n';
 }
 


### PR DESCRIPTION
## Changed
- 기존에 map으로 관리하던 전체 유저, 채널에서 특정 유저에 접근할 때 [] 연산자를 이용하여 접근했습니다.
- 무조건 있는 케이스만 있다고 생각해서 이렇게 진행했었는데, non-blocking 특성 상 클라이언트가 삭제된 후 read나 send event를 처리하는 경우가 있었습니다.
- 따라서, [] 연산자로 접근하는 케이스를 모두 find를 사용하도록 수정하였고, 타겟을 찾지 못한 경우 return 하도록 수정하였습니다.

Co-authored-by: kyj93790 <kyj93790@naver.com>