### PR TITLE
[FIX] Reply to all other users when a user change one's nickname

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -189,7 +189,7 @@ bool Command::cmdNick(Server& server, User *user, const Message& msg) {
 			return false;
 		}
 	}
-	user->addToReplyBuffer(Message() << ":" << originNickname << msg.getCommand() << requestNickname);
+	user->broadcastToMyChannels(Message() << ":" << originNickname << msg.getCommand() << requestNickname);
 	return true;
 }
 

--- a/User.hpp
+++ b/User.hpp
@@ -7,6 +7,8 @@
 # include <vector>
 using namespace std;
 
+# define UNDEFINED_FD -1
+
 class Channel;
 class Message;
 class User {
@@ -52,7 +54,7 @@ class User {
 		void addToMyChannelList(Channel* channel);
 		void deleteFromMyChannelList(Channel* channel);
 		void clearMyChannelList(void);
-		void broadcastToMyChannels(const Message& msg, const int ignoreFd) const;
+		void broadcastToMyChannels(const Message& msg, const int ignoreFd = UNDEFINED_FD) const;
 };
 
 #endif


### PR DESCRIPTION
## Issue
- #18 

## Explanation
- User nickname 변경 시, 해당 user가 포함된 모든 채널의 user들이 변경 여부를 알 수 있어야 함
- 기존 코드는 변경 성공 여부를 본인에게만 전달함

## Changed
- nickname을 변경한 user가 포함된 모든 Channel에 해당 user의 nickname 변경 정보를 broadcast