### PR TITLE
[BUG] 없는 유저 KICK 했을 때 segmentation fault 발생 현상 수정

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -58,6 +58,17 @@ User* Channel::findUser(const int clientFd) {
     return it->second;
 }
 
+User* Channel::findUser(const string& nickname) {
+    map<int, User *>::iterator it;
+
+    for(it = _userList.begin(); it != _userList.end(); ++it) {
+        User *user = it->second;
+
+        if (user->getNickname() == nickname) return user;
+    }
+    return NULL;
+}
+
 bool Channel::isUserOper(int clientFd) const {
     set<int>::iterator it;
 

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -35,6 +35,7 @@ class Channel {
         void addUser(int clientFd, User *user);
         int deleteUser(int clientFd);
         User* findUser(const int clientFd);
+        User* findUser(const string& nickname);
         bool isUserOper(int clientFd) const;
         void broadcast(const Message& msg, int ignoreFd = UNDEFINED_FD);
 };

--- a/Command.cpp
+++ b/Command.cpp
@@ -261,12 +261,6 @@ bool Command::cmdQuit(Server& server, User *user, const Message& msg) {
 bool Command::cmdKick(Server& server, User *user, const Message& msg) {
 	if (msg.paramSize() < 2)
 		user->addToReplyBuffer(Message() << ":" << SERVER_HOSTNAME << ERR_NEEDMOREPARAMS << user->getNickname() << msg.getCommand() << ERR_NEEDMOREPARAMS_MSG);
-
-	string reason;
-	if (msg.paramSize() >= 3) {
-		reason.append(":");
-		reason.append(msg.getParams()[2]);
-	}
 	
 	// 해당 channel이 존재하는 지 check
 	Channel *targetChannel = server.findChannelByName(msg.getParams()[0]);
@@ -289,15 +283,24 @@ bool Command::cmdKick(Server& server, User *user, const Message& msg) {
 
 	// iteration
 	const vector<string> targetUsers = Message::split(msg.getParams()[1], ',');
+	string reason;
+	if (msg.paramSize() >= 3) {
+		reason.append(":");
+		reason.append(msg.getParams()[2]);
+	}
+
 	for (vector<string>::const_iterator it = targetUsers.begin(); it != targetUsers.end(); ++it) {
 		// target User가 channel에 존재하는지
-		int targetFd = server.findClientByNickname(*it)->getFd();
-		if (targetChannel->findUser(targetFd) == NULL)
+		User *targetUser = targetChannel->findUser(*it);
+
+		if (targetUser == NULL) {
 			user->addToReplyBuffer(Message() << ":" << SERVER_HOSTNAME << ERR_USERNOTINCHANNEL << user->getNickname() << *it << msg.getParams()[0] << ERR_USERNOTINCHANNEL_MSG);
+			continue;
+		}
 
 		// 존재하면 Kick (그 channel에 deleteUser)
-		targetChannel->broadcast(Message() << ":" << user->getNickname() << msg.getCommand() << msg.getParams()[0] << *it << ":" << user->getNickname());
-		const int remainUsers = targetChannel->deleteUser(targetFd);
+		targetChannel->broadcast(Message() << ":" << user->getNickname() << msg.getCommand() << msg.getParams()[0] << *it << reason);
+		const int remainUsers = targetChannel->deleteUser(targetUser->getFd());
 		if (remainUsers == 0) server.deleteChannel(targetChannel->getName());
 	}
 	return true;


### PR DESCRIPTION
## Issue
- #2 

## Changed
- Channel class에 유저 닉네임으로 검색할 수 있는 findUser function이 오버로딩 되었습니다.
- findUser로 user를 찾은 후에 있는 경우에만 다음 단계로 진행되도록 수정되었습니다.
- KICK reason이 전달되지 않는 부분을 발견하여 수정하였습니다.