### PR TITLE
[BUG] NICK: reply message depending on joining channel #30

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -189,7 +189,8 @@ bool Command::cmdNick(Server& server, User *user, const Message& msg) {
 			return false;
 		}
 	}
-	user->broadcastToMyChannels(Message() << ":" << originNickname << msg.getCommand() << requestNickname);
+	if (user->getMyAllChannel().empty()) user->addToReplyBuffer(Message() << ":" << originNickname << msg.getCommand() << requestNickname);
+	else user->broadcastToMyChannels(Message() << ":" << originNickname << msg.getCommand() << requestNickname);
 	return true;
 }
 


### PR DESCRIPTION
## Issue
- #30

## Explanation
- User가 어떤 Channel에도 소속되지 않은 경우 NICK command에 대해 reply message를 보내지 않음
- 이로 인해 해당 user가 nickname 변경 성공 여부를 인식할 수 없음
- User의 화면상 nickname 변경이 이루어지지 않음

## Changed
- User가 속한 Channel이 없는 경우, 해당 user에게만 reply message를 별도로 전송

Co-authored-by: kyj93790 <kyj93790@naver.com>