### PR TITLE
[FIX] Nickname - set max size, check is valid format

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -4,7 +4,9 @@
 #include "User.hpp"
 #include "Message.hpp"
 
+#include "CommonValue.hpp"
 #include "Reply.hpp"
+#include "FormatValidator.hpp"
 
 #include <iostream>
 
@@ -165,7 +167,7 @@ bool Command::cmdNick(Server& server, User *user, const Message& msg) {
 		user->addToReplyBuffer(Message() << ":" << SERVER_HOSTNAME << ERR_NEEDMOREPARAMS << user->getNickname() << msg.getCommand() << ERR_NEEDMOREPARAMS_MSG);
 		return true;
 	}
-	const string requestNickname = msg.getParams()[0];
+	string requestNickname = msg.getParams()[0];
 	const string originNickname = user->getNickname();
 
 	if (requestNickname.length() == 0) {
@@ -178,6 +180,11 @@ bool Command::cmdNick(Server& server, User *user, const Message& msg) {
 		return true;
 	}
 	
+	if (requestNickname.length() > MAX_NICKNAME_LEN) requestNickname = requestNickname.erase(MAX_NICKNAME_LEN);
+	if (!FormatValidator::isValidNickname(requestNickname)) {
+		user->addToReplyBuffer(Message() << ":" << SERVER_HOSTNAME << ERR_ERRONEUSNICKNAME << requestNickname << ERR_ERRONEUSNICKNAME_MSG);
+		return true;
+	}
 	user->setNickname(requestNickname);
 	if (!user->getAuth() && !user->getUsername().empty()) {
 		if (server.checkPassword(user->getPassword())) {

--- a/CommonValue.hpp
+++ b/CommonValue.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#ifndef COMMONVALUE_HPP
+# define COMMONVALUE_HPP
+
+# define MAX_NICKNAME_LEN 9
+
+#endif

--- a/FormatValidator.cpp
+++ b/FormatValidator.cpp
@@ -1,0 +1,31 @@
+#include "FormatValidator.hpp"
+
+bool FormatValidator::isTargetChar(const char dst, const char src) {
+    return (dst == src);
+}
+
+bool FormatValidator::isLetter(const char dst) {
+    return (tolower(dst) >= 'a' && tolower(dst) <= 'z');
+}
+
+bool FormatValidator::isDigit(const char dst) {
+    return (dst >= '0' && dst <= '9');
+}
+
+bool FormatValidator::isSpecial(const char dst) {
+    return ((dst >= '[' && dst <= '`') || (dst >= '{' && dst <= '}'));
+}
+
+bool FormatValidator::isValidNickname(const string& nickname) {
+    string::const_iterator it = nickname.begin();
+
+    if (!isLetter(*it) && !isSpecial(*it)) return false;
+
+    ++it;
+    for (; it != nickname.end(); ++it) {
+        if (isLetter(*it) || isDigit(*it) || isSpecial(*it) || isTargetChar(*it, '-')) continue;
+
+        return false;
+    }
+    return true;
+}

--- a/FormatValidator.hpp
+++ b/FormatValidator.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifndef FORMATVALIDATOR_HPP
+# define FORMATVALIDATOR_HPP
+
+#include <string>
+
+using namespace std;
+
+struct FormatValidator {
+    static bool isTargetChar(const char dst, const char src);
+    static bool isLetter(const char dst);
+    static bool isDigit(const char dst);
+    static bool isSpecial(const char dst);
+
+    static bool isValidNickname(const string& nickname);
+};
+
+#endif

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 NAME	= ircserv
 
 ################ FILE ################
-SRCS	= main.cpp Server.cpp Channel.cpp User.cpp Message.cpp Command.cpp Bot.cpp
+SRCS	= main.cpp Server.cpp Channel.cpp User.cpp Message.cpp Command.cpp FormatValidator.cpp Bot.cpp
 
 ################ OBJ #################
 OBJS	= $(SRCS:%.cpp=%.o)

--- a/Reply.hpp
+++ b/Reply.hpp
@@ -26,6 +26,7 @@
 # define ERR_NONICKNAMEGIVEN "431"
 # define ERR_NONICKNAMEGIVEN_MSG ":No nickname given"
 # define ERR_ERRONEUSNICKNAME "432"
+# define ERR_ERRONEUSNICKNAME_MSG ":Erroneous nickname"
 # define ERR_NICKNAMEINUSE "433"
 # define ERR_NICKNAMEINUSE_MSG ":Nickname is already in use"
 


### PR DESCRIPTION
## Issue
- #32 
상용 서버의 경우 nickname의 최대 글자수 제한을 설정파일에 설정합니다.(보통 30글자 정도)
-> 우리 서버는 헤더에 define한 값으로 적용하려 합니다.(RFC 문서에 언급되어있는 값인 9로 설정됨)

## Changed
1. NICK command로 들어온 param의 길이가 9를 초과하면 뒷 부분을 잘라서 사용(dalnet에서 처리하는 방식)
2. nickname 형식 체크(RFC 문서 명세)
a. FormatValidator struct 생성하여 형식에 맞는지 체크함
b. 체크할 때 사용하는 letter, digit, special은 RFC 명세에서 정의하는 값에 맞게 체크하도록 했습니다.
