### PR TITLE
[FIX] Channelname: max len(31, include '#'), check illegal char

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -88,6 +88,11 @@ bool Command::cmdJoin(Server& server, User *user, const Message& msg) {
 			user->addToReplyBuffer(Message() << ":" << SERVER_HOSTNAME << ERR_NOSUCHCHANNEL << user->getNickname() << targetChannelName << ERR_NOSUCHCHANNEL_MSG);
 			continue;
 		}
+		if (targetChannelName.length() > 31) targetChannelName.erase(MAX_CHANNELNAME_LEN);
+		if (!FormatValidator::isValidChannelname(targetChannelName)) {
+			user->addToReplyBuffer(Message() << ":" << SERVER_HOSTNAME << ERR_ERRONEUSCHANNELNAME << user->getNickname() << targetChannelName << ERR_ERRONEUSCHANNELNAME_MSG);
+			continue;
+		}
 
         Channel *targetChannel;
 

--- a/CommonValue.hpp
+++ b/CommonValue.hpp
@@ -4,5 +4,6 @@
 # define COMMONVALUE_HPP
 
 # define MAX_NICKNAME_LEN 9
+# define MAX_CHANNELNAME_LEN 31
 
 #endif

--- a/FormatValidator.cpp
+++ b/FormatValidator.cpp
@@ -29,3 +29,14 @@ bool FormatValidator::isValidNickname(const string& nickname) {
     }
     return true;
 }
+
+bool FormatValidator::isValidChannelname(const string& channelname) {
+    string::const_iterator it = channelname.begin();
+
+    for (; it != channelname.end(); ++it) {
+        if (!isTargetChar(*it, 7)) continue;
+
+        return false;
+    }
+    return true;
+}

--- a/FormatValidator.hpp
+++ b/FormatValidator.hpp
@@ -14,6 +14,7 @@ struct FormatValidator {
     static bool isSpecial(const char dst);
 
     static bool isValidNickname(const string& nickname);
+    static bool isValidChannelname(const string& channelname);
 };
 
 #endif

--- a/Reply.hpp
+++ b/Reply.hpp
@@ -44,6 +44,8 @@
 # define ERR_PASSWDMISMATCH_MSG ":Password incorrect"
 
 # define ERR_CHANNELISFULL "471"
+# define ERR_ERRONEUSCHANNELNAME "479"
+# define ERR_ERRONEUSCHANNELNAME_MSG ":Channel name contains illegal characters"
 # define ERR_CHANOPRIVSNEEDED "482"
 # define ERR_CHANOPRIVSNEEDED_MSG ":You're not channel operator"
 


### PR DESCRIPTION
## Issue
- #33 

## Changed
1. 채널명 최대 31글자(맨 앞 '#' 포함, 더 긴 param 들어올 시 뒷부분 잘라내고 처리)
2. BELL (ASCII 7) 문자 제한
a. FormatValidator의 isValidChannelname 사용