### PR TITLE
[FIX] QUIT - remove check paramSize, reply Error to quiting client

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -273,12 +273,16 @@ bool Command::cmdQuit(User *user, const Message& msg) {
 	else reason += "leaving";
 
 	user->clearCmdBuffer();
-	user->clearReplyBuffer();
-	user->setIsQuiting();
+	user->setReplyBuffer("\r\nERROR :Closing Link: " + user->getHost() + " " + reason + "\r\n");
 
 	int clientFd = user->getFd();
-	user->setReplyBuffer("\r\nERROR :Closing Link: " + user->getHost() + " " + reason + "\r\n");
 	user->broadcastToMyChannels(Message() << ":" << user->getSource() << msg.getCommand() << reason, clientFd);
+	const vector<Channel *> userChannelList = user->getMyAllChannel();
+	for (vector<Channel *>::const_iterator it = userChannelList.begin(); it != userChannelList.end(); ++it) {
+		const int remainUsers = (*it)->deleteUser(user->getFd());
+		if (remainUsers == 0) _server.deleteChannel((*it)->getName());
+	}
+	user->setIsQuiting();
 	return false;
 }
 

--- a/Command.hpp
+++ b/Command.hpp
@@ -18,7 +18,7 @@ struct Command
 	static bool cmdNick(Server& server, User *user, const Message& msg);
 	static bool cmdUser(Server& server, User *user, const Message& msg);
 	static bool cmdPing(User *user, const Message& msg);
-	static bool cmdQuit(Server& server, User *user, const Message& msg);
+	static bool cmdQuit(User *user, const Message& msg);
 	static bool cmdKick(Server& server, User *user, const Message& msg);
 	static bool cmdNotice(Server& server, User *user, const Message& msg);
 };

--- a/Server.cpp
+++ b/Server.cpp
@@ -92,6 +92,7 @@ void Server::sendDataToClient(const struct kevent& event) {
 		disconnectClient(event.ident);  
 	} else {
 		targetUser->setReplyBuffer(targetUser->getReplyBuffer().substr(readBytes));
+		if (targetUser->getIsQuiting() && targetUser->getReplyBuffer().empty()) disconnectClient(event.ident);
 	}
 }
 

--- a/Server.cpp
+++ b/Server.cpp
@@ -193,7 +193,13 @@ void Server::disconnectClient(int clientFd) {
 	User* targetUser = it->second;
 
 	if (it == _allUser.end()) return ;
+
     _allUser.erase(clientFd);
+	const vector<Channel *> userChannelList = targetUser->getMyAllChannel();
+	for (vector<Channel *>::const_iterator it = userChannelList.begin(); it != userChannelList.end(); ++it) {
+		const int remainUsers = (*it)->deleteUser(targetUser->getFd());
+		if (remainUsers == 0) deleteChannel((*it)->getName());
+	}
 	delete targetUser;
 	cout << "client disconnected: " << clientFd << '\n';
 }

--- a/User.cpp
+++ b/User.cpp
@@ -7,9 +7,6 @@ User::User(int fd, const string& host) : _fd(fd), _host(host), _auth(false), _is
 
 User::~User() {
     close(_fd);
-    for (vector<Channel *>::iterator it = _myChannelList.begin(); it != _myChannelList.end(); ++it) {
-        (*it)->deleteUser(_fd);
-    }
     _myChannelList.clear();
 }
 

--- a/User.cpp
+++ b/User.cpp
@@ -3,7 +3,7 @@
 #include "Channel.hpp"
 #include "Message.hpp"
 
-User::User(int fd, const string& host) : _fd(fd), _host(host), _auth(false) { }
+User::User(int fd, const string& host) : _fd(fd), _host(host), _auth(false), _isQuiting(false) { }
 
 User::~User() {
     close(_fd);
@@ -15,6 +15,10 @@ User::~User() {
 
 int User::getFd(void) const {
     return _fd;
+}
+
+const string& User::getHost(void) const {
+    return _host;
 }
 
 const string& User::getPassword(void) const {
@@ -55,6 +59,10 @@ const vector<Channel *>& User::getMyAllChannel(void) const {
     return _myChannelList;
 }
 
+bool User::getIsQuiting(void) const {
+    return _isQuiting;
+}
+
 void User::setPassword(const string& pwd) {
     _password = pwd;
 }
@@ -75,12 +83,20 @@ void User::setCmdBuffer(const string& str) {
     _cmdBuffer = str;
 }
 
+void User::clearCmdBuffer(void) {
+    _cmdBuffer.clear();
+}
+
 void User::setReplyBuffer(const string& str) {
     _replyBuffer = str;
 }
 
 void User::setReplyBuffer(const Message& msg) {
     _replyBuffer = msg.createReplyForm();
+}
+
+void User::clearReplyBuffer(void) {
+    _replyBuffer.clear();
 }
 
 void User::addToCmdBuffer(const string& str) {
@@ -117,4 +133,8 @@ void User::broadcastToMyChannels(const Message& msg, const int ignoreFd) const {
 	for (vector<Channel *>::const_iterator it = chs.begin(); it != chs.end(); ++it) {
 		(*it)->broadcast(msg, ignoreFd);
 	}
+}
+
+void User::setIsQuiting(void) {
+    _isQuiting = true;
 }

--- a/User.hpp
+++ b/User.hpp
@@ -22,6 +22,7 @@ class User {
 		string _cmdBuffer;
 		string _replyBuffer;
 		vector<Channel *> _myChannelList;
+		bool _isQuiting;
 
 		User(void);
 		User(const User& user);
@@ -32,6 +33,7 @@ class User {
 		~User();
 		
 		int getFd(void) const;
+		const string& getHost(void) const;
 		const string& getPassword(void) const;
 		const string getNickname(void) const;
 		const string getSource(void) const;
@@ -40,15 +42,19 @@ class User {
 		const string& getCmdBuffer(void) const;
 		const string& getReplyBuffer(void) const;
 		const vector<Channel *>& getMyAllChannel(void) const;
+		bool getIsQuiting(void) const;
 
 		void setPassword(const string& pwd);
 		void setNickname(const string& nickname);
 		void setUsername(const string& username);
 		void setAuth(void);
+		void setIsQuiting(void);
 
 		void setCmdBuffer(const string& src);
+		void clearCmdBuffer(void);
 		void setReplyBuffer(const string& src);
 		void setReplyBuffer(const Message& msg);
+		void clearReplyBuffer(void);
 		void addToCmdBuffer(const string& src);
 		void addToReplyBuffer(const string& src);
 		void addToReplyBuffer(const Message& msg);
@@ -57,6 +63,7 @@ class User {
 		void deleteFromMyChannelList(Channel* channel);
 		void clearMyChannelList(void);
 		void broadcastToMyChannels(const Message& msg, const int ignoreFd = UNDEFINED_FD) const;
+
 };
 
 #endif


### PR DESCRIPTION
## Issue
- #42 

## Changed
1. cmdQuit에서 paramSize() 체크 삭제
2. quit하는 클라이언트에게 ERROR 전송 확인 후 disconnectClient 호출
- ERROR 메시지를 replyBuffer에 추가하고 바로 disconnectClient를 호출하는 경우 정상적으로 메시지가 전송되지 않는 경우가 발생했습니다.
- 따라서, 해당 유저의 buffer를 모두 지워준 뒤, \r\n 으로 감싼 에러 메시지를 replyBuffer에 세팅했습니다.(partial write 일 때를 고려하여 앞에서 쓰던 reply message를 마무리하기 위해 앞에도 붙여주었습니다.)
- 추가적으로 User class에 isQuiting이라는 bool 값의 member variable을 추가하고 cmdQuit이 들어온 경우 true로 설정해주었습니다.
- 서버에서 해당 client fd에 write가 가능하다는 이벤트를 받아 write를 하는 경우 해당 user의 isQuiting flag를 체크하고, isQuiting && replyBuffer 가 비었을 때(아까 추가해둔 ERROR 문구를 전송했을 때) disconnect 하도록 처리했습니다.
3. User의 소멸자에서 해당 유저가 속해있는 채널들을 나가도록 되어있었는데, QUIT이나 socket 에러로 서버에서 유저를 종료시키는 경우에는 해당 채널들의 삭제를 할 수 없는 문제가 있어서 해당 로직을 cmdQuit과 disconnectClient로 이동하였습니다.