### PR TITLE
[BUG] Server: print message to console before delete channel

### DIFF
--- a/Server.cpp
+++ b/Server.cpp
@@ -182,9 +182,9 @@ void Server::deleteChannel(const string& name) {
 
 	if (it == _allChannel.end()) return ;
 	
+	cout << "Delete channel from server: " << name << '\n';
 	_allChannel.erase(name);
 	delete ch;
-	cout << "channel deleted: " << name << '\n';
 }
 
 void Server::disconnectClient(int clientFd) {


### PR DESCRIPTION
## Issue
- #44 
- deleteChannel function에서 채널 이름을 reference로 받고 있었는데, 해당 인자를 delete channel 후에 출력문에서 사용하여 segmentation fault가 발생했습니다.
## Changed
출력문을 delete 위로 이동하였습니다.