### PR TITLE
[FIX] Prefix check sent by client

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -26,7 +26,10 @@ Command::~Command() {
 }
 
 bool Command::run(User *user, const Message& msg) {
+	const string& prefix = msg.getPrefix();
 	const string& cmd = msg.getCommand();
+
+	if (!prefix.empty() && prefix != user->getNickname()) return true;
 
 	try {
 		return (this->*_commands.at(cmd))(user, msg);

--- a/Message.cpp
+++ b/Message.cpp
@@ -15,9 +15,13 @@ void Message::parse(const string& ircMsgFormStr) {
     vector<string> splitedBySpace = split(ircMsgFormStr, ' ');
 
     for (vector<string>::size_type i = 0; i < splitedBySpace.size(); ++i) {
-        if (i == 0) {
-            _command = splitedBySpace[i];
+        if (i == 0 && splitedBySpace[i][0] == ':') {
+            _prefix = splitedBySpace[i].erase(0, 1);
             continue ;
+        }
+        if (_command.empty()) {
+            _command = splitedBySpace[i];
+            continue;
         }
         if (splitedBySpace[i][0] == ':') {
             string mergedString;
@@ -32,6 +36,11 @@ void Message::parse(const string& ircMsgFormStr) {
         } else _params.push_back(splitedBySpace[i]);
     }
 }
+
+const string& Message::getPrefix(void) const {
+    return _prefix;
+}
+
 const string& Message::getCommand(void) const {
     return _command;
 }

--- a/Message.hpp
+++ b/Message.hpp
@@ -11,6 +11,7 @@ class Server;
 class User;
 class Message {
     private:
+        string _prefix;
         string _command;
         vector<string> _params;
         
@@ -24,6 +25,7 @@ class Message {
         Message(const string& ircMsgFormStr);
         ~Message();
 
+        const string& getPrefix(void) const;
         const string& getCommand(void) const;
         const vector<string>& getParams(void) const;
 


### PR DESCRIPTION
## Issue
- #37 
- RFC 문서 상에서 Client가 사용할 수 있는 prefix는 오직 자기 자신의 nickname 뿐이라고 규정하고 있습니다.

## Changed
- Message class에서 prefix member variable을 추가했습니다.
- Command::run에서 handling 중인 message에 prefix가 있는 경우, valid한 지 확인 후 처리합니다.
- invalid한 prefix의 경우 해당 message를 무시합니다.