### PR TITLE
[FIX] set nonblocking fd on client socket, check errno set by read/write on client fd

### DIFF
--- a/Server.cpp
+++ b/Server.cpp
@@ -46,6 +46,7 @@ void Server::acceptNewClient(void) {
 	memset(hostStr, 0, sizeof(hostStr));
 	if ((clientSocket = accept(_fd, (struct sockaddr *)&clientAddr, &addrLen)) == ERR_RETURN)
 		throw(runtime_error("accept() error"));
+	fcntl(clientSocket, F_SETFL, O_NONBLOCK);
 	inet_ntop(AF_INET, &clientAddr.sin_addr, hostStr, INET_ADDRSTRLEN);
 	cout << "accept new client: " << clientSocket << " / Host : " << hostStr << endl;
 	fcntl(clientSocket, F_SETFL, O_NONBLOCK);

--- a/Server.hpp
+++ b/Server.hpp
@@ -13,6 +13,7 @@
 # include <arpa/inet.h>
 # include <unistd.h>
 # include <fcntl.h>
+# include <sys/errno.h>
 # include <vector>
 
 # include "User.hpp"

--- a/Server.hpp
+++ b/Server.hpp
@@ -50,7 +50,7 @@ class Server {
         void updateEvents(int socket, int16_t filter, uint16_t flags, uint32_t fflags, intptr_t data, void *udata);
 
         void acceptNewClient(void);
-        void readDataFromClient(const struct kevent& event);
+        void recvDataFromClient(const struct kevent& event);
         void sendDataToClient(const struct kevent& event);
         void handleEvent(const struct kevent& event);
 


### PR DESCRIPTION
## Issue
- #50 
<img width="493" alt="image" src="https://user-images.githubusercontent.com/60038526/216812541-7f3e5d19-9301-4b69-b0cb-ab83f5d0f956.png">

## Changed
- subject의 요구사항대로 모든 fd에 대해 non-blocking으로 설정하였습니다.
- non-blocking fd에 read/write를 하는 경우, 일시적인 자원 부족으로 -1이 return 되고 errno가 EAGAIN 혹은 EWOULDBLOCK으로 설정될 수 있습니다.
- 해당 케이스는 일시적인 현상으로 client의 연결을 종료하지 않고 나중에 다시 시도하도록 해당 함수를 일단 종료하도록 처리되었습니다.