### PR TITLE
[BUG] remove kicked channel in my channel list

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -327,6 +327,7 @@ bool Command::cmdKick(User *user, const Message& msg) {
 		targetChannel->broadcast(Message() << ":" << user->getSource() << msg.getCommand() << msg.getParams()[0] << *it << reason);
 		const int remainUsers = targetChannel->deleteUser(targetUser->getFd());
 		if (remainUsers == 0) _server.deleteChannel(targetChannel->getName());
+		targetUser->deleteFromMyChannelList(targetChannel);
 	}
 	return true;
 }


### PR DESCRIPTION
## Issue
- #45
- 채널에서 KICK 된 경우, 해당 유저의 채널 목록에서 지워주지 않아서 유저가 disconnect 될 때 해당 채널에 broadcast 되는 문제
- 특히, 이미 채널이 지워진 경우 segmentation fault 발생

## Changed
- KICK 된 유저의 채널 리스트에서 해당 채널을 지우도록 처리했습니다.