### PR TITLE
[BUG] clear user's myChannelList after leave all channels

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -285,6 +285,7 @@ bool Command::cmdQuit(User *user, const Message& msg) {
 		const int remainUsers = (*it)->deleteUser(user->getFd());
 		if (remainUsers == 0) _server.deleteChannel((*it)->getName());
 	}
+	user->clearMyChannelList();
 	user->setIsQuiting();
 	return false;
 }

--- a/Command.cpp
+++ b/Command.cpp
@@ -277,15 +277,7 @@ bool Command::cmdQuit(User *user, const Message& msg) {
 
 	user->clearCmdBuffer();
 	user->setReplyBuffer("\r\nERROR :Closing Link: " + user->getHost() + " " + reason + "\r\n");
-
-	int clientFd = user->getFd();
-	user->broadcastToMyChannels(Message() << ":" << user->getSource() << msg.getCommand() << reason, clientFd);
-	const vector<Channel *> userChannelList = user->getMyAllChannel();
-	for (vector<Channel *>::const_iterator it = userChannelList.begin(); it != userChannelList.end(); ++it) {
-		const int remainUsers = (*it)->deleteUser(user->getFd());
-		if (remainUsers == 0) _server.deleteChannel((*it)->getName());
-	}
-	user->clearMyChannelList();
+	user->broadcastToMyChannels(Message() << ":" << user->getSource() << msg.getCommand() << reason, user->getFd());
 	user->setIsQuiting();
 	return false;
 }

--- a/Server.cpp
+++ b/Server.cpp
@@ -210,6 +210,7 @@ void Server::disconnectClient(int clientFd) {
 		const int remainUsers = (*it)->deleteUser(targetUser->getFd());
 		if (remainUsers == 0) deleteChannel((*it)->getName());
 	}
+	targetUser->clearMyChannelList();
 	delete targetUser;
 	cout << "client disconnected: " << clientFd << '\n';
 }

--- a/User.cpp
+++ b/User.cpp
@@ -7,7 +7,6 @@ User::User(int fd, const string& host) : _fd(fd), _host(host), _auth(false), _is
 
 User::~User() {
     close(_fd);
-    _myChannelList.clear();
 }
 
 int User::getFd(void) const {


### PR DESCRIPTION
## Issue
- #55 
cmdQuit과 disconnectClient 모두 해당 유저를 채널 리스트에서 탈퇴 시킵니다. 이 때, 해당 유저가 가지고 있는 myChannelList를 돌면서 처리해주고 있는데, cmdQuit에서 해당 로직 처리 후 해당 유저의 myChannelList를 초기화해주지 않았습니다.
그 후, disconnectClient에서 한 번 더 myChannelList를 돌면서 같은 로직을 실행하게 되는데, 이미 삭제된 채널의 경우 delete 된 주소로 접근하게 되면서 segmentation falut가 발생했습니다

## Changed
유저를 모든 채널에서 탈퇴시키는 로직을 실행한 후에 해당 유저의 myChannelList를 비우도록 수정했습니다.