### PR TITLE
[BUG] Command: check auth before run command

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -30,6 +30,7 @@ bool Command::run(User *user, const Message& msg) {
 	const string& cmd = msg.getCommand();
 
 	if (!prefix.empty() && prefix != user->getNickname()) return true;
+	if (!user->getAuth() && isCommandNeedAuth(cmd)) return true;
 
 	try {
 		return (this->*_commands.at(cmd))(user, msg);
@@ -362,5 +363,11 @@ bool Command::cmdNotice(User *user, const Message& msg) {
             targetUser->addToReplyBuffer(Message() << ":" << user->getSource() << msg.getCommand() << targetName << ":" << msg.getParams()[1]);
         }
     }
+	return true;
+}
+
+bool Command::isCommandNeedAuth(const string& cmd) {
+	if (cmd == "PASS" || cmd == "NICK" || cmd == "USER" || cmd == "PING" || cmd == "QUIT") return false;
+
 	return true;
 }

--- a/Command.hpp
+++ b/Command.hpp
@@ -32,6 +32,8 @@ class Command {
 		bool cmdKick(User *user, const Message& msg);
 		bool cmdNotice(User *user, const Message& msg);
 
+		bool isCommandNeedAuth(const string& cmd);
+
 	public:
 		Command(Server& server);
 		~Command();


### PR DESCRIPTION
## Issue
- #58 

## Changed
- new member method: isCommandNeedAuth()
  - user의 auth가 필요없는 커맨드의 경우에 false를 return 합니다.
  - 필요없는 커맨드를 체크하도록 하여 새로운 커맨드를 추가했을 때 기본 설정이 "인증 필요"가 되도록 하였습니다.