### PR TITLE
[FIX] Server: Fail to accept only cut the connection of that client

### DIFF
--- a/Server.cpp
+++ b/Server.cpp
@@ -44,8 +44,11 @@ void Server::acceptNewClient(void) {
 
 	memset(&clientAddr, 0, sizeof(clientAddr));
 	memset(hostStr, 0, sizeof(hostStr));
-	if ((clientSocket = accept(_fd, (struct sockaddr *)&clientAddr, &addrLen)) == ERR_RETURN)
-		throw(runtime_error("accept() error"));
+	if ((clientSocket = accept(_fd, (struct sockaddr *)&clientAddr, &addrLen)) == ERR_RETURN) {
+		cerr << "aceept() failed! Check errno : " << errno << endl;
+		errno = 0;
+		return ;
+	}
 	if (_allUser.size() >= MAX_USER_NUM) {
 		cout << "Server reached max number of user" << endl;
 		close(clientSocket);


### PR DESCRIPTION
## Issue
- #54 

## Changed
- 기존에 accept()에서 오류가 발생할 시 exception을 던져서 서버가 종료되었습니다.
- 새로 접속하는 유저의 문제는 기존에 이용 중인 유저와 관계가 없을 확률이 높습니다.
- 따라서, accept() 실패 시 설정된 errno를 cerr로 출력하여 관리자가 handle 하도록 수정하였습니다.